### PR TITLE
Updated GraphQLUnionType.getTypes()

### DIFF
--- a/graphql.d.ts
+++ b/graphql.d.ts
@@ -807,9 +807,7 @@ declare module 'graphql' {
         description: string;
         resolveType: (value: any, info?: GraphQLResolveInfo) => GraphQLObjectType;
         constructor(config: GraphQLUnionTypeConfig);
-        getPossibleTypes(): Array<GraphQLObjectType>;
-        isPossibleType(type: GraphQLObjectType): boolean;
-        getObjectType(value: any, info: GraphQLResolveInfo): GraphQLObjectType;
+        getTypes(): Array<GraphQLObjectType>
         toString(): string;
     }
 


### PR DESCRIPTION
Also, remove functions that doesn't seem to be in GraphQLUnion
[Link](https://github.com/graphql/graphql-js/blob/master/src/type/definition.js#L657)
